### PR TITLE
HttpClient related fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.2.0] - Unreleased
-* Allowed to replace nested HttpClient during runtime thanks to `setHttpClient`
+* Allowed to replace nested Symfony HttpClient during runtime thanks to `setWrappedHttpClient`
 * Removed useless `api_platform_ms.http_repository.http_repository` service definition
-* Added query params to AbstractHttpMicroserviceRepository
+* Added query params to `AbstractHttpMicroserviceRepository`
 * Added nested resource denormalization
-* Fixed lowest symfony/property-access version to 4.4
+* Fixed lowest `symfony/property-access` version to 4.4
 * Replaced Travis CI by Github actions
 * Removed PHPCPD QA checks
 

--- a/src/HttpClient/GenericHttpClient.php
+++ b/src/HttpClient/GenericHttpClient.php
@@ -9,7 +9,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
- * @final @internal
+ * @final
  */
 class GenericHttpClient
 {
@@ -58,12 +58,12 @@ class GenericHttpClient
         return $this->httpClient->request($method, $uri, $options);
     }
 
-    public function getHttpClient(): HttpClientInterface
+    public function getWrappedHttpClient(): HttpClientInterface
     {
         return $this->httpClient;
     }
 
-    public function setHttpClient(HttpClientInterface $httpClient): void
+    public function setWrappedHttpClient(HttpClientInterface $httpClient): void
     {
         $this->httpClient = $httpClient;
     }

--- a/src/HttpClient/MicroserviceHttpClient.php
+++ b/src/HttpClient/MicroserviceHttpClient.php
@@ -6,7 +6,7 @@ use Mtarld\ApiPlatformMsBundle\Microservice\MicroservicePool;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
- * @final @internal
+ * @final
  */
 class MicroserviceHttpClient implements MicroserviceHttpClientInterface
 {

--- a/src/HttpClient/ReplaceableHttpClientInterface.php
+++ b/src/HttpClient/ReplaceableHttpClientInterface.php
@@ -4,7 +4,10 @@ namespace Mtarld\ApiPlatformMsBundle\HttpClient;
 
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
+/**
+ * @internal
+ */
 interface ReplaceableHttpClientInterface
 {
-    public function setHttpClient(HttpClientInterface $httpClient): void;
+    public function setWrappedHttpClient(HttpClientInterface $httpClient): void;
 }

--- a/src/HttpClient/ReplaceableHttpClientTrait.php
+++ b/src/HttpClient/ReplaceableHttpClientTrait.php
@@ -4,10 +4,13 @@ namespace Mtarld\ApiPlatformMsBundle\HttpClient;
 
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
+/**
+ * @internal
+ */
 trait ReplaceableHttpClientTrait
 {
-    public function setHttpClient(HttpClientInterface $httpClient): void
+    public function setWrappedHttpClient(HttpClientInterface $httpClient): void
     {
-        $this->httpClient->setHttpClient($httpClient);
+        $this->httpClient->setWrappedHttpClient($httpClient);
     }
 }

--- a/tests/ApiResource/ExistenceCheckerTest.php
+++ b/tests/ApiResource/ExistenceCheckerTest.php
@@ -118,7 +118,7 @@ class ExistenceCheckerTest extends KernelTestCase
         $existenceChecker = static::$container->get('api_platform_ms.api_resource.existence_checker');
         $existenceChecker->getExistenceStatuses('bar', ['1']);
 
-        $existenceChecker->setHttpClient($secondHttpClient);
+        $existenceChecker->setWrappedHttpClient($secondHttpClient);
         $existenceChecker->getExistenceStatuses('bar', ['1']);
     }
 }

--- a/tests/Collection/PaginatedCollectionIteratorTest.php
+++ b/tests/Collection/PaginatedCollectionIteratorTest.php
@@ -120,7 +120,7 @@ class PaginatedCollectionIteratorTest extends KernelTestCase
             self::assertEquals($expectedElements[$index++], $element);
 
             if (3 === $index) {
-                $iterator->setHttpClient($secondHttpClient);
+                $iterator->setWrappedHttpClient($secondHttpClient);
             }
         }
     }

--- a/tests/HttpClient/HttpClientTest.php
+++ b/tests/HttpClient/HttpClientTest.php
@@ -127,7 +127,7 @@ class HttpClientTest extends KernelTestCase
 
         $microserviceHttpClient->request('GET', '/puppies');
 
-        $microserviceHttpClient->setHttpClient($secondHttpClient);
+        $microserviceHttpClient->setWrappedHttpClient($secondHttpClient);
         $microserviceHttpClient->request('GET', '/puppies');
     }
 }

--- a/tests/HttpRepository/HttpRepositoryTest.php
+++ b/tests/HttpRepository/HttpRepositoryTest.php
@@ -263,7 +263,7 @@ class HttpRepositoryTest extends KernelTestCase
         $puppyDto = $httpRepository->findOneByIri('/puppies/1');
         self::assertEquals(new PuppyResourceDto('/puppies/1', 'foo'), $puppyDto);
 
-        $httpRepository->setHttpClient($secondHttpClient);
+        $httpRepository->setWrappedHttpClient($secondHttpClient);
 
         $puppyDto = $httpRepository->findOneByIri('/puppies/1');
         self::assertEquals(new PuppyResourceDto('/puppies/1', 'foo'), $puppyDto);


### PR DESCRIPTION
Fixes #16 

- Renamed `setHttpClient` to `setWrappedHttpClient`
- Renamed `getHttpClient` to `getWrappedHttpClient`
- Made `ReplaceableHttpClientInterface` and `ReplaceableHttpTrait` internal