### PR TITLE
[HttpRepository] Fetch resources using criteria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.3.0] - Unreleased
+* Deprecated `findOneByIri`, `findOneBy`, `findBy`, `findAll` methods in `AbstractMicroserviceHttpRepository`
+* Added `fetchOneByIri`, `fetchOneBy`, `fetchBy`, `fetchAll` methods in `AbstractMicroserviceHttpRepository`
 * Deprecated `PaginatedCollectionIterator::iterateOver`
 * Added `PaginatedCollectionIterator::iterateItems`
 * Added `PaginatedCollectionIterator::iteratePages`

--- a/src/HttpRepository/AbstractMicroserviceHttpRepository.php
+++ b/src/HttpRepository/AbstractMicroserviceHttpRepository.php
@@ -19,7 +19,6 @@ use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
-use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 // Help opcache.preload discover always-needed symbols
@@ -32,6 +31,9 @@ class_exists(ResourceValidationException::class);
 class_exists(ServerException::class);
 class_exists(SerializerExceptionInterface::class);
 
+/**
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ */
 abstract class AbstractMicroserviceHttpRepository implements ReplaceableHttpClientInterface
 {
     use ReplaceableHttpClientTrait;
@@ -60,9 +62,9 @@ abstract class AbstractMicroserviceHttpRepository implements ReplaceableHttpClie
     /**
      * @psalm-param array<mixed> $additionalQueryParams
      *
-     * @throws HttpExceptionInterface
+     * @throws ExceptionInterface
      */
-    public function findOneByIri(string $iri, array $additionalQueryParams = []): ?ApiResourceDtoInterface
+    public function fetchOneByIri(string $iri, array $additionalQueryParams = []): ?ApiResourceDtoInterface
     {
         try {
             /** @var ApiResourceDtoInterface|null $resource */
@@ -83,6 +85,34 @@ abstract class AbstractMicroserviceHttpRepository implements ReplaceableHttpClie
     }
 
     /**
+     * @deprecated since version 0.3.0, will be removed in 1.0. Use {@see \Mtarld\ApiPlatformMsBundle\HttpRepository\AbstractMicroserviceHttpRepository::fetchOneByIri()} instead.
+     *
+     * @psalm-param array<mixed> $additionalQueryParams
+     *
+     * @throws ExceptionInterface
+     */
+    public function findOneByIri(string $iri, array $additionalQueryParams = []): ?ApiResourceDtoInterface
+    {
+        return $this->fetchOneByIri($iri, $additionalQueryParams);
+    }
+
+    /**
+     * @psalm-param array<mixed> $criteria
+     * @psalm-param array<mixed> $additionalQueryParams
+     *
+     * @throws ExceptionInterface
+     */
+    public function fetchOneBy(array $criteria, array $additionalQueryParams = []): ?ApiResourceDtoInterface
+    {
+        $items = iterator_to_array($this->fetchBy($criteria, $additionalQueryParams));
+        $item = reset($items);
+
+        return false !== $item ? $item : null;
+    }
+
+    /**
+     * @deprecated since version 0.3.0, will be removed in 1.0. Use {@see \Mtarld\ApiPlatformMsBundle\HttpRepository\AbstractMicroserviceHttpRepository::fetchOneBy()} instead.
+     *
      * @psalm-param scalar $value
      * @psalm-param array<mixed> $additionalQueryParams
      *
@@ -90,13 +120,24 @@ abstract class AbstractMicroserviceHttpRepository implements ReplaceableHttpClie
      */
     public function findOneBy(string $property, $value, array $additionalQueryParams = []): ?ApiResourceDtoInterface
     {
-        $items = iterator_to_array($this->findBy($property, [$value], $additionalQueryParams));
-        $item = reset($items);
-
-        return false !== $item ? $item : null;
+        return $this->fetchOneBy([$property => $value], $additionalQueryParams);
     }
 
     /**
+     * @psalm-param array<scalar|array<scalar>> $criteria
+     * @psalm-param array<mixed> $additionalQueryParams
+     * @psalm-return Collection<ApiResourceDtoInterface>
+     *
+     * @throws ExceptionInterface
+     */
+    public function fetchBy(array $criteria, array $additionalQueryParams = []): Collection
+    {
+        return $this->requestCollection($criteria + $additionalQueryParams);
+    }
+
+    /**
+     * @deprecated since version 0.3.0, will be removed in 1.0. Use {@see \Mtarld\ApiPlatformMsBundle\HttpRepository\AbstractMicroserviceHttpRepository::fetchBy()} instead.
+     *
      * @psalm-param array<scalar> $values
      * @psalm-param array<mixed> $additionalQueryParams
      * @psalm-return Collection<ApiResourceDtoInterface>
@@ -105,7 +146,7 @@ abstract class AbstractMicroserviceHttpRepository implements ReplaceableHttpClie
      */
     public function findBy(string $property, array $values, array $additionalQueryParams = []): Collection
     {
-        return $this->requestCollection([$property => $values] + $additionalQueryParams);
+        return $this->fetchBy([$property => $values], $additionalQueryParams);
     }
 
     /**
@@ -114,9 +155,22 @@ abstract class AbstractMicroserviceHttpRepository implements ReplaceableHttpClie
      *
      * @throws ExceptionInterface
      */
-    public function findAll(array $additionalQueryParams = []): Collection
+    public function fetchAll(array $additionalQueryParams = []): Collection
     {
         return $this->requestCollection($additionalQueryParams);
+    }
+
+    /**
+     * @deprecated since version 0.3.0, will be removed in 1.0. Use {@see \Mtarld\ApiPlatformMsBundle\HttpRepository\AbstractMicroserviceHttpRepository::fetchAll()} instead.
+     *
+     * @psalm-return Collection<ApiResourceDtoInterface>
+     * @psalm-param array<mixed> $additionalQueryParams
+     *
+     * @throws ExceptionInterface
+     */
+    public function findAll(array $additionalQueryParams = []): Collection
+    {
+        return $this->fetchAll($additionalQueryParams);
     }
 
     /**

--- a/src/Resources/doc/tools/http-repository.md
+++ b/src/Resources/doc/tools/http-repository.md
@@ -16,9 +16,11 @@ class ProductHttpRepository extends AbstractMicroserviceHttpRepository
     /**
      * Custom method
      */
-    public function findOneByName(string $name): ?ProductDto
+    public function fetchOneByName(string $name): ?ProductDto
     {
-        return parent::findOneBy('name', $name);
+        return parent::fetchOneBy([
+            'name' => $name,
+        ]);
     }
 
     protected function getMicroserviceName(): string
@@ -47,13 +49,13 @@ class ProductController extends AbstractController
     public function byName(Request $request, ProductHttpRepository $productHttpRepository)
     {
         return $this->render('product.html.twig', [
-            'product' => $productHttpRepository->findOneByName($request->query->get('name')),
+            'product' => $productHttpRepository->fetchOneByName($request->query->get('name')),
         ]);
     }
 
     public function updateFirstProduct(ProductHttpRepository $productHttpRepository)
     {
-        $product = $productHttpRepository->findOneByIri('/products/1');
+        $product = $productHttpRepository->fetchOneByIri('/products/1');
         $product->setName('new name');
 
         $productHttpRepository->update($product);

--- a/tests/HttpRepository/HttpRepositoryTest.php
+++ b/tests/HttpRepository/HttpRepositoryTest.php
@@ -61,7 +61,7 @@ class HttpRepositoryTest extends KernelTestCase
         /** @var PuppyHttpRepository $httpRepository */
         $httpRepository = static::$container->get(PuppyHttpRepository::class);
 
-        $puppyDto = $httpRepository->findOneByIri('/puppies/1');
+        $puppyDto = $httpRepository->fetchOneByIri('/puppies/1');
         self::assertEquals(new PuppyResourceDto('/puppies/1', 'foo'), $puppyDto);
     }
 
@@ -76,7 +76,7 @@ class HttpRepositoryTest extends KernelTestCase
         /** @var PuppyHttpRepository $httpRepository */
         $httpRepository = static::$container->get(PuppyHttpRepository::class);
 
-        $puppyDto = $httpRepository->findOneByIri('/puppies/1');
+        $puppyDto = $httpRepository->fetchOneByIri('/puppies/1');
         self::assertNull($puppyDto);
     }
 
@@ -114,7 +114,7 @@ class HttpRepositoryTest extends KernelTestCase
         /** @var PuppyHttpRepository $httpRepository */
         $httpRepository = static::$container->get(PuppyHttpRepository::class);
 
-        $puppyDtos = $httpRepository->findBy('superName', ['foo', 'bar'], ['groups' => ['translations']]);
+        $puppyDtos = $httpRepository->fetchBy(['superName' => ['foo', 'bar']], ['groups' => ['translations']]);
         self::assertCount(2, $puppyDtos);
         self::assertNotNull($puppyDtos->getMicroservice());
     }
@@ -136,7 +136,7 @@ class HttpRepositoryTest extends KernelTestCase
             ->method('request')
             ->with(
                 'GET',
-                '/api/puppies?superName%5B0%5D=foo',
+                '/api/puppies?superName=foo',
                 [
                     'base_uri' => 'https://localhost',
                     'headers' => [
@@ -153,7 +153,7 @@ class HttpRepositoryTest extends KernelTestCase
         /** @var PuppyHttpRepository $httpRepository */
         $httpRepository = static::$container->get(PuppyHttpRepository::class);
 
-        $puppyDto = $httpRepository->findOneBy('superName', 'foo');
+        $puppyDto = $httpRepository->fetchOneBy(['superName' => 'foo']);
         self::assertEquals(new PuppyResourceDto('/puppies/1', 'foo'), $puppyDto);
     }
 
@@ -174,7 +174,7 @@ class HttpRepositoryTest extends KernelTestCase
             ->method('request')
             ->with(
                 'GET',
-                '/api/puppies?superName%5B0%5D=foo',
+                '/api/puppies?superName%5B0%5D=foo&superName%5B1%5D=bar',
                 [
                     'base_uri' => 'https://localhost',
                     'headers' => [
@@ -191,7 +191,7 @@ class HttpRepositoryTest extends KernelTestCase
         /** @var PuppyHttpRepository $httpRepository */
         $httpRepository = static::$container->get(PuppyHttpRepository::class);
 
-        $puppyDto = $httpRepository->findOneBy('superName', 'foo');
+        $puppyDto = $httpRepository->fetchOneBy(['superName' => ['foo', 'bar']]);
         self::assertNull($puppyDto);
     }
 
@@ -229,7 +229,7 @@ class HttpRepositoryTest extends KernelTestCase
         /** @var PuppyHttpRepository $httpRepository */
         $httpRepository = static::$container->get(PuppyHttpRepository::class);
 
-        $puppyDtos = $httpRepository->findAll(['itemsPerPage' => 2]);
+        $puppyDtos = $httpRepository->fetchAll(['itemsPerPage' => 2]);
         self::assertCount(2, $puppyDtos);
         self::assertNotNull($puppyDtos->getMicroservice());
     }
@@ -264,12 +264,12 @@ class HttpRepositoryTest extends KernelTestCase
         /** @var PuppyHttpRepository $httpRepository */
         $httpRepository = static::$container->get(PuppyHttpRepository::class);
 
-        $puppyDto = $httpRepository->findOneByIri('/puppies/1');
+        $puppyDto = $httpRepository->fetchOneByIri('/puppies/1');
         self::assertEquals(new PuppyResourceDto('/puppies/1', 'foo'), $puppyDto);
 
         $httpRepository->setWrappedHttpClient($secondHttpClient);
 
-        $puppyDto = $httpRepository->findOneByIri('/puppies/1');
+        $puppyDto = $httpRepository->fetchOneByIri('/puppies/1');
         self::assertEquals(new PuppyResourceDto('/puppies/1', 'foo'), $puppyDto);
     }
 


### PR DESCRIPTION
As said in #34, this PR allows the `AbstractMicroserviceHttpRepository` to fetch resources using criteria. 
Therefore, `AbstractMicroserviceHttpRepository` will be able to **fetch resources in several fields**.

In order to prevent BC breaks, `findOneByIri`, `findOneBy`, `findBy`, `findAll` methods have been deprecated in favor of `fetchOneByIri`, `fetchOneBy`, `fetchBy`, `fetchAll`, which are by the way more meaningful IMHO.

Closes #34.