### PR TITLE
[HTTPCLient] Add AccessTokenCreator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.3.0] - Unreleased
+* Added authentication header providers
 * Deprecated `findOneByIri`, `findOneBy`, `findBy`, `findAll` methods in `AbstractMicroserviceHttpRepository`
 * Added `fetchOneByIri`, `fetchOneBy`, `fetchBy`, `fetchAll` methods in `AbstractMicroserviceHttpRepository`
 * Deprecated `PaginatedCollectionIterator::iterateOver`

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ And you're ready to go ! :rocket:
 - [**HTTP client wrappers**](src/Resources/doc/tools/http-wrapper.md):
   Clients that adapt HTTP calls according to the targeted microservice configuration.
 
+- [**Authentication header providers**](src/Resources/doc/tools/authentication-header-provider.md):
+Providers that dynamically inject authentication headers in requests.
+
 - [**ConstraintViolation list denormalizer**](src/Resources/doc/tools/constraint-violation-list.md)
   Allows you to create a `ConstraintViolationList` instance from a serialized string.
 

--- a/src/DependencyInjection/ApiPlatformMsExtension.php
+++ b/src/DependencyInjection/ApiPlatformMsExtension.php
@@ -2,12 +2,14 @@
 
 namespace Mtarld\ApiPlatformMsBundle\DependencyInjection;
 
+use Mtarld\ApiPlatformMsBundle\HttpClient\AuthenticationHeaderProviderInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 
 // Help opcache.preload discover always-needed symbols
+class_exists(AuthenticationHeaderProviderInterface::class);
 class_exists(FileLocator::class);
 class_exists(PhpFileLoader::class);
 
@@ -61,5 +63,7 @@ class ApiPlatformMsExtension extends Extension
         $container->setParameter('api_platform_ms.hosts', $config['hosts']);
         $container->setParameter('api_platform_ms.microservices', $config['microservices']);
         $container->setParameter('api_platform_ms.enabled_formats', $formats);
+
+        $container->registerForAutoconfiguration(AuthenticationHeaderProviderInterface::class)->addTag('api_platform_ms.authentication_header_provider');
     }
 }

--- a/src/HttpClient/AuthenticationHeaderProviderInterface.php
+++ b/src/HttpClient/AuthenticationHeaderProviderInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Mtarld\ApiPlatformMsBundle\HttpClient;
+
+/**
+ * @author Smaïne Milianni <smaine.milianni@gmail.com>
+ */
+interface AuthenticationHeaderProviderInterface
+{
+    public function getHeader(): string;
+
+    public function getValue(): string;
+
+    /**
+     * @psalm-param array<array-key, mixed> $context
+     */
+    public function supports(array $context): bool;
+}

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -12,6 +12,7 @@ use Mtarld\ApiPlatformMsBundle\Validator\ApiResourceExistValidator;
 use Mtarld\ApiPlatformMsBundle\Validator\FormatEnabledValidator;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ReferenceConfigurator;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
 
 return static function (ContainerConfigurator $container): void {
     $container->services()
@@ -40,6 +41,7 @@ return static function (ContainerConfigurator $container): void {
             ->args([
                 service('serializer'),
                 service('api_platform_ms.http_client'),
+                tagged_iterator('api_platform_ms.authentication_header_provider'),
             ])
         ->alias(GenericHttpClient::class, 'api_platform_ms.http_client.generic')
         ->set('api_platform_ms.api_resource.existence_checker', ExistenceChecker::class)

--- a/src/Resources/doc/tools/authentication-header-provider.md
+++ b/src/Resources/doc/tools/authentication-header-provider.md
@@ -1,0 +1,53 @@
+# Authentication header providers
+## Motivation
+Most of the time, microservices will need an authentication header.
+In that way, they will know who is doing the request and to authorize
+it to interact with a resource or not.
+
+Even if authentication headers are part of the request headers,
+we don't want to specify them each time we call the `request` method.
+Therefore, we can use authentication header providers to inject authentication headers
+in requests and decouple them from the regular headers.
+
+## Description
+Create your Provider and implements `AuthenticationHeaderProviderInterface`.
+Behind the scene the Http Client will iterate over them and call `AuthenticationHeaderProviderInterface::supports` in order to fetch the good provider.
+
+You can refer to the [Symfony documentation](https://symfony.com/doc/current/service_container/tags.html) to know more about Service Tags (autoconfiguration, priority...)
+
+## Here is an example
+```yaml
+services:
+    _defaults:
+        autoconfigure: true
+```
+
+```php
+use App\User\Security\OAuthAccessTokenInterface;
+use Mtarld\ApiPlatformMsBundle\HttpClient\AuthenticationHeaderProviderInterface;
+class BearerAuthenticationHeaderProvider implements AuthenticationHeaderProviderInterface
+{
+    private $accessToken;
+    public function __construct(OAuthAccessTokenInterface $accessToken)
+    {
+        $this->accessToken = $accessToken;
+    }
+    public function getHeader() : string
+    {
+        return 'Authorization';
+    }
+    public function getValue() : string
+    {
+        return sprintf('Bearer %s', $this->accessToken->getOAuthAccessToken());
+    }
+    public function supports(array $context) : bool
+    {
+        // $context is an hashmap containing 'method', 'uri', 'options' and 'microservice'.
+        return null !== $this->accessToken->getOAuthAccessToken() && 'product' === $context['microservice']->getName();
+    }
+    public static function getDefaultPriority(): int
+    {
+        return 10;
+    }
+}
+```

--- a/tests/Fixtures/App/config/config.yml
+++ b/tests/Fixtures/App/config/config.yml
@@ -34,25 +34,22 @@ services:
     autoconfigure: true
     public: true
 
+  Mtarld\ApiPlatformMsBundle\Tests\Fixtures\App\src\:
+    resource: '%kernel.project_dir%/src'
+    exclude: '%kernel.project_dir%/src/{Dto,Entity}'
+
   test.iri_converter:
     alias: api_platform.iri_converter
-    public: true
 
   test.existence_checker:
     alias: api_platform_ms.api_resource.existence_checker
-    public: true
 
   test.http_client:
     alias: api_platform_ms.http_client
-    public: true
 
   test.logger:
     alias: logger
-    public: true
 
   Mtarld\ApiPlatformMsBundle\Collection\PaginatedCollectionIterator: ~
 
-  Mtarld\ApiPlatformMsBundle\Tests\Fixtures\App\src\HttpRepository\PuppyHttpRepository: ~
-
   Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter: ~
-

--- a/tests/Fixtures/App/src/Authentication/BasicAuthenticationHeaderProvider.php
+++ b/tests/Fixtures/App/src/Authentication/BasicAuthenticationHeaderProvider.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Mtarld\ApiPlatformMsBundle\Tests\Fixtures\App\src\Authentication;
+
+use Mtarld\ApiPlatformMsBundle\HttpClient\AuthenticationHeaderProviderInterface;
+use Mtarld\ApiPlatformMsBundle\Microservice\Microservice;
+
+/**
+ * @author Smaïne Milianni <smaine.milianni@gmail.com>
+ */
+class BasicAuthenticationHeaderProvider implements AuthenticationHeaderProviderInterface
+{
+    private $enabled = false;
+
+    public function getHeader(): string
+    {
+        return 'Authorization';
+    }
+
+    public function getValue(): string
+    {
+        return 'Basic password';
+    }
+
+    public function supports(array $context): bool
+    {
+        /** @var Microservice $ms */
+        $ms = $context['microservice'];
+
+        return $this->enabled && '/api/puppies' === $context['uri'] && 'GET' === $context['method'] && 'bar' == $ms->getName();
+    }
+
+    public function setEnabled(bool $enabled): void
+    {
+        $this->enabled = $enabled;
+    }
+}

--- a/tests/Fixtures/App/src/Authentication/BearerAuthenticationHeaderProvider.php
+++ b/tests/Fixtures/App/src/Authentication/BearerAuthenticationHeaderProvider.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Mtarld\ApiPlatformMsBundle\Tests\Fixtures\App\src\Authentication;
+
+use Mtarld\ApiPlatformMsBundle\HttpClient\AuthenticationHeaderProviderInterface;
+
+/**
+ * @author Smaïne Milianni <smaine.milianni@gmail.com>
+ */
+class BearerAuthenticationHeaderProvider implements AuthenticationHeaderProviderInterface
+{
+    private $enabled = false;
+
+    public function getHeader(): string
+    {
+        return 'Authorization';
+    }
+
+    public function getValue(): string
+    {
+        return 'Bearer bearer';
+    }
+
+    public function supports(array $context): bool
+    {
+        return $this->enabled && '/api/dummies' === $context['uri'] && 'DELETE' === $context['method'];
+    }
+
+    public function setEnabled(bool $enabled): void
+    {
+        $this->enabled = $enabled;
+    }
+}

--- a/tests/HttpClient/HttpClientTest.php
+++ b/tests/HttpClient/HttpClientTest.php
@@ -6,6 +6,8 @@ use Mtarld\ApiPlatformMsBundle\HttpClient\GenericHttpClient;
 use Mtarld\ApiPlatformMsBundle\HttpClient\MicroserviceHttpClientInterface;
 use Mtarld\ApiPlatformMsBundle\Microservice\Microservice;
 use Mtarld\ApiPlatformMsBundle\Microservice\MicroservicePool;
+use Mtarld\ApiPlatformMsBundle\Tests\Fixtures\App\src\Authentication\BasicAuthenticationHeaderProvider;
+use Mtarld\ApiPlatformMsBundle\Tests\Fixtures\App\src\Authentication\BearerAuthenticationHeaderProvider;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -129,5 +131,39 @@ class HttpClientTest extends KernelTestCase
 
         $microserviceHttpClient->setWrappedHttpClient($secondHttpClient);
         $microserviceHttpClient->request('GET', '/puppies');
+    }
+
+    /**
+     * @dataProvider authenticationHeadersDataProvider
+     */
+    public function testAuthenticationHeaders(string $microservice, string $method, $uri, array $expectedAuthenticationHeader): void
+    {
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient
+            ->expects(self::once())
+            ->method('request')
+            ->with(
+                $method,
+                $uri,
+                [
+                    'base_uri' => 'https://localhost',
+                    'headers' => ['Content-Type' => 'application/ld+json', 'Accept' => 'application/ld+json'] + $expectedAuthenticationHeader,
+                ]
+            )
+            ->willReturn($this->createMock(ResponseInterface::class))
+        ;
+        static::$container->set('test.http_client', $httpClient);
+
+        static::$container->get(BasicAuthenticationHeaderProvider::class)->setEnabled(true);
+        static::$container->get(BearerAuthenticationHeaderProvider::class)->setEnabled(true);
+
+        static::$container->get(GenericHttpClient::class)->request(static::$container->get(MicroservicePool::class)->get($microservice), $method, $uri);
+    }
+
+    public function authenticationHeadersDataProvider(): iterable
+    {
+        yield ['bar', 'POST', '/api/puppies', []];
+        yield ['bar', 'GET', '/api/puppies', ['Authorization' => 'Basic password']];
+        yield ['bar', 'DELETE', '/api/dummies', ['Authorization' => 'Bearer bearer']];
     }
 }


### PR DESCRIPTION
Should resolve #35 

AccessTokenCreator are autoconfigured and the end user can deal with priority in the service definition, the first  AccessTokenCreator that returns an access token is defined to retrieve an access token and the header

Not sure about : 

~~- the namespace~~
~~- credential in PHP doc~~

- [x] Tests
- [x] Documentation 