### PR TITLE
fix(deprecation): src

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
     "symfony/browser-kit": "^4.3|^5.0",
     "symfony/framework-bundle": "^4.4|^5.0",
     "symfony/phpunit-bridge": "^4.4|^5.0",
+    "symfony/routing": "^4.4|^5.0",
     "symfony/twig-bundle": "^3.4|^4.0|^5.0",
     "symfony/yaml": "^3.4|^4.0|^5.0",
     "vimeo/psalm": "^3.10|^4.3"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,7 +12,7 @@
 >
     <php>
         <ini name="error_reporting" value="-1"/>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0" />
         <env name="APP_DEBUG" value="0"/>
         <env name="KERNEL_CLASS" value="Mtarld\ApiPlatformMsBundle\Tests\Fixtures\App\AppKernel"/>
     </php>

--- a/src/DependencyInjection/ApiPlatformMsExtension.php
+++ b/src/DependencyInjection/ApiPlatformMsExtension.php
@@ -3,6 +3,7 @@
 namespace Mtarld\ApiPlatformMsBundle\DependencyInjection;
 
 use Mtarld\ApiPlatformMsBundle\HttpClient\AuthenticationHeaderProviderInterface;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
@@ -75,6 +76,8 @@ class ApiPlatformMsExtension extends Extension
 
     /**
      * {@inheritdoc}
+     *
+     * @return ConfigurationInterface|null
      */
     public function getConfiguration(array $config, ContainerBuilder $container)
     {

--- a/src/Serializer/AbstractApiResourceDenormalizer.php
+++ b/src/Serializer/AbstractApiResourceDenormalizer.php
@@ -32,6 +32,8 @@ abstract class AbstractApiResourceDenormalizer implements DenormalizerInterface,
      * @param mixed  $data
      * @param string $type
      * @param string $format
+     *
+     * @return mixed
      */
     public function denormalize($data, $type, $format = null, array $context = [])
     {

--- a/src/Serializer/Hal/ObjectDenormalizer.php
+++ b/src/Serializer/Hal/ObjectDenormalizer.php
@@ -22,6 +22,8 @@ class ObjectDenormalizer implements DenormalizerInterface, DenormalizerAwareInte
      * @param mixed  $data
      * @param string $type
      * @param string $format
+     *
+     * @return mixed
      */
     public function denormalize($data, $type, $format = null, array $context = [])
     {

--- a/src/Serializer/JsonApi/ObjectDenormalizer.php
+++ b/src/Serializer/JsonApi/ObjectDenormalizer.php
@@ -27,6 +27,8 @@ class ObjectDenormalizer implements ContextAwareDenormalizerInterface, Denormali
      * @param mixed  $data
      * @param string $type
      * @param string $format
+     *
+     * @return mixed
      */
     public function denormalize($data, $type, $format = null, array $context = [])
     {


### PR DESCRIPTION
- Locking `symfony/routing` to be less than `6.0` to avoid incompatibility between APIP and Symfony routing
- Only track direct deprecations (as a lot of deprecations are triggered because of APIP/Symfony link)
- Add missing `@return` tags