### PR TITLE
Symfony 6 support

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -82,7 +82,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1']
+                php-versions: ['7.3', '7.4', '8.0', '8.1']
             fail-fast: false
         name: PHP ${{ matrix.php-versions }} tests
         steps:
@@ -113,7 +113,7 @@ jobs:
 
     phpunit-lowest:
         runs-on: ubuntu-latest
-        name: PHP 7.1 (lowest) tests
+        name: PHP 7.2 (lowest) tests
         steps:
             - name: Checkout
               uses: actions/checkout@v2
@@ -121,7 +121,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: '7.1'
+                  php-version: '7.2'
 
             - name: Get composer cache directory
               id: composercache

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "php": "^7.2|^8.0",
     "api-platform/core": "^2.5",
     "symfony/http-client": "^4.4|^5.0|^6.0",
-    "symfony/property-access": "^4.4|^5.0|^5.0",
+    "symfony/property-access": "^4.4|^5.0|^6.0",
     "symfony/serializer": "^4.4|^5.0|^6.0",
     "symfony/validator": "^4.4|^5.0|^6.0",
     "symfony/event-dispatcher": "^4.4|^5.0|^6.0",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     }
   ],
   "require": {
-    "php": "^7.1|^8.0",
+    "php": "^7.2|^8.0",
     "api-platform/core": "^2.5",
     "symfony/http-client": "^4.4|^5.0|^6.0",
     "symfony/property-access": "^4.4|^5.0|^5.0",

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "doctrine/annotations": "^1.7",
     "friendsofphp/php-cs-fixer": "^3.1",
     "phpmd/phpmd": "^2.8",
-    "phpunit/phpunit": "^7.5|^8.3|^9.5",
+    "phpunit/phpunit": "^7.5|^8.4|^9.5",
     "psalm/plugin-phpunit": "^0.15",
     "symfony/browser-kit": "^4.3|^5.0|^6.0",
     "symfony/framework-bundle": "^4.4|^5.0|^6.0",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     }
   ],
   "require": {
-    "php": "^7.2|^8.0",
+    "php": "^7.1|^8.0",
     "api-platform/core": "^2.5",
     "symfony/http-client": "^4.4|^5.0|^6.0",
     "symfony/property-access": "^4.4|^5.0|^5.0",

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
     }
   ],
   "require": {
-    "php": "^7.1|^8.0",
+    "php": "^7.2|^8.0",
     "api-platform/core": "^2.5",
-    "symfony/http-client": "^4.4|^5.0",
-    "symfony/property-access": "^4.4|^5.0",
-    "symfony/serializer": "^4.4|^5.0",
-    "symfony/validator": "^4.4|^5.0",
-    "symfony/event-dispatcher": "^4.4|^5.0",
+    "symfony/http-client": "^4.4|^5.0|^6.0",
+    "symfony/property-access": "^4.4|^5.0|^5.0",
+    "symfony/serializer": "^4.4|^5.0|^6.0",
+    "symfony/validator": "^4.4|^5.0|^6.0",
+    "symfony/event-dispatcher": "^4.4|^5.0|^6.0",
     "symfony/polyfill-php80": "^1.20",
     "psr/log": "^1.0"
   },
@@ -42,17 +42,22 @@
     "doctrine/annotations": "^1.7",
     "friendsofphp/php-cs-fixer": "^3.1",
     "phpmd/phpmd": "^2.8",
-    "phpunit/phpunit": "^7.5|^8.4|^9.5",
+    "phpunit/phpunit": "^7.5|^8.3|^9.5",
     "psalm/plugin-phpunit": "^0.15",
-    "symfony/browser-kit": "^4.3|^5.0",
-    "symfony/framework-bundle": "^4.4|^5.0",
-    "symfony/phpunit-bridge": "^4.4|^5.0",
-    "symfony/routing": "^4.4|^5.0",
-    "symfony/twig-bundle": "^3.4|^4.0|^5.0",
-    "symfony/yaml": "^3.4|^4.0|^5.0",
+    "symfony/browser-kit": "^4.3|^5.0|^6.0",
+    "symfony/framework-bundle": "^4.4|^5.0|^6.0",
+    "symfony/phpunit-bridge": "^4.4|^5.0|^6.0",
+    "symfony/routing": "^4.4|^5.0|^6.0",
+    "symfony/twig-bundle": "^3.4|^4.0|^5.0|^6.0",
+    "symfony/yaml": "^3.4|^4.0|^5.0|^6.0",
     "vimeo/psalm": "^3.10|^4.3"
   },
   "scripts": {
     "php-cs-fixer": "vendor/bin/php-cs-fixer fix --dry-run --format checkstyle"
+  },
+  "config": {
+    "allow-plugins": {
+      "composer/package-versions-deprecated": true
+    }
   }
 }

--- a/src/Serializer/AbstractApiResourceDenormalizer.php
+++ b/src/Serializer/AbstractApiResourceDenormalizer.php
@@ -3,6 +3,7 @@
 namespace Mtarld\ApiPlatformMsBundle\Serializer;
 
 use Mtarld\ApiPlatformMsBundle\Dto\ApiResourceDtoInterface;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -35,7 +36,7 @@ abstract class AbstractApiResourceDenormalizer implements DenormalizerInterface,
      *
      * @return mixed
      *
-     * @throws \Symfony\Component\Serializer\Exception\ExceptionInterface
+     * @throws ExceptionInterface
      */
     public function denormalize($data, $type, $format = null, array $context = [])
     {

--- a/src/Serializer/AbstractApiResourceDenormalizer.php
+++ b/src/Serializer/AbstractApiResourceDenormalizer.php
@@ -30,9 +30,9 @@ abstract class AbstractApiResourceDenormalizer implements DenormalizerInterface,
     abstract protected function prepareEmbeddedData(array $data): array;
 
     /**
-     * @param mixed  $data
-     * @param string $type
-     * @param string|null   $format
+     * @param mixed       $data
+     * @param string      $type
+     * @param string|null $format
      *
      * @return mixed
      *

--- a/src/Serializer/AbstractApiResourceDenormalizer.php
+++ b/src/Serializer/AbstractApiResourceDenormalizer.php
@@ -35,6 +35,7 @@ abstract class AbstractApiResourceDenormalizer implements DenormalizerInterface,
      *
      * @return mixed
      */
+    #public function denormalize($data, string $type, string $format = null, array $context = [])
     public function denormalize($data, $type, $format = null, array $context = [])
     {
         $iri = $this->getIri($data);
@@ -48,7 +49,7 @@ abstract class AbstractApiResourceDenormalizer implements DenormalizerInterface,
     /**
      * @param mixed  $data
      * @param string $type
-     * @param string $format
+     * @param string|null $format
      */
     public function supportsDenormalization($data, $type, $format = null): bool
     {

--- a/src/Serializer/AbstractApiResourceDenormalizer.php
+++ b/src/Serializer/AbstractApiResourceDenormalizer.php
@@ -31,11 +31,12 @@ abstract class AbstractApiResourceDenormalizer implements DenormalizerInterface,
     /**
      * @param mixed  $data
      * @param string $type
-     * @param string $format
+     * @param null   $format
      *
      * @return mixed
+     *
+     * @throws \Symfony\Component\Serializer\Exception\ExceptionInterface
      */
-    #public function denormalize($data, string $type, string $format = null, array $context = [])
     public function denormalize($data, $type, $format = null, array $context = [])
     {
         $iri = $this->getIri($data);
@@ -47,8 +48,8 @@ abstract class AbstractApiResourceDenormalizer implements DenormalizerInterface,
     }
 
     /**
-     * @param mixed  $data
-     * @param string $type
+     * @param mixed       $data
+     * @param string      $type
      * @param string|null $format
      */
     public function supportsDenormalization($data, $type, $format = null): bool

--- a/src/Serializer/AbstractApiResourceDenormalizer.php
+++ b/src/Serializer/AbstractApiResourceDenormalizer.php
@@ -31,7 +31,7 @@ abstract class AbstractApiResourceDenormalizer implements DenormalizerInterface,
     /**
      * @param mixed  $data
      * @param string $type
-     * @param null   $format
+     * @param string|null   $format
      *
      * @return mixed
      *

--- a/tests/HttpRepository/HttpRepositoryTest.php
+++ b/tests/HttpRepository/HttpRepositoryTest.php
@@ -415,7 +415,7 @@ class HttpRepositoryTest extends BcLayerKernelTestCase
     public function testPartialUpdateResource(): void
     {
         /** @var SerializerInterface $serializer */
-        $serializer = static::$container->get(SerializerInterface::class);
+        $serializer = static::getContainer()->get(SerializerInterface::class);
 
         $response = $this->createMock(ResponseInterface::class);
         $response
@@ -442,10 +442,10 @@ class HttpRepositoryTest extends BcLayerKernelTestCase
             ->willReturn($response)
         ;
 
-        static::$container->set('test.http_client', $httpClient);
+        static::getContainer()->set('test.http_client', $httpClient);
 
         /** @var PuppyHttpRepository $httpRepository */
-        $httpRepository = static::$container->get(PuppyHttpRepository::class);
+        $httpRepository = static::getContainer()->get(PuppyHttpRepository::class);
 
         $updatedPuppyDto = $httpRepository->partialUpdate(new PuppyResourceDto('/puppies/1', 'foo'), ['user' => 'me']);
         self::assertEquals(new PuppyResourceDto('/puppies/1', 'foo'), $updatedPuppyDto);
@@ -456,7 +456,7 @@ class HttpRepositoryTest extends BcLayerKernelTestCase
         $this->expectException(ResourceValidationException::class);
 
         /** @var SerializerInterface $serializer */
-        $serializer = static::$container->get(SerializerInterface::class);
+        $serializer = static::getContainer()->get(SerializerInterface::class);
 
         $httpClient = new MockHttpClient([
             new MockResponse(
@@ -467,10 +467,10 @@ class HttpRepositoryTest extends BcLayerKernelTestCase
             ),
         ]);
 
-        static::$container->set('test.http_client', $httpClient);
+        static::getContainer()->set('test.http_client', $httpClient);
 
         /** @var PuppyHttpRepository $httpRepository */
-        $httpRepository = static::$container->get(PuppyHttpRepository::class);
+        $httpRepository = static::getContainer()->get(PuppyHttpRepository::class);
         $httpRepository->partialUpdate(new PuppyResourceDto('/puppies/1', 'foo'));
     }
 
@@ -480,7 +480,7 @@ class HttpRepositoryTest extends BcLayerKernelTestCase
         $this->expectExceptionMessage('Cannot partially update a resource without iri');
 
         /** @var PuppyHttpRepository $httpRepository */
-        $httpRepository = static::$container->get(PuppyHttpRepository::class);
+        $httpRepository = static::getContainer()->get(PuppyHttpRepository::class);
         $httpRepository->partialUpdate(new PuppyResourceDto(null, 'foo'));
     }
 


### PR DESCRIPTION
Hi. 

https://github.com/mtarld/api-platform-ms-bundle/issues/61

I am not sure if we need to bump php from 7.1 to 7.2.
Tests are green with 7.1. But i do not know why.
PhpStorm is nagging me about https://github.com/mtarld/api-platform-ms-bundle/compare/master...art-cg:feature/symfony6-support?expand=1#diff-81e685cfc62637750b05f5f0e61b7b3be5e4bfc40bd48d1dfc20eb1013dfd56bR40

See https://github.com/FriendsOfSymfony/FOSJsRoutingBundle/pull/408#issuecomment-994558671

My only explanation of this (at the moment) is that this is this is not covered by Tests, magic in symfony/polyfill-php72 ?