### PR TITLE
feat: PHP CS Fixer - set Line-Ending

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -15,6 +15,7 @@ return $config
         'ordered_imports' => ['sort_algorithm' => 'alpha'],
     ])
     ->setRiskyAllowed(true)
+    ->setLineEnding("\n")
     ->setFinder($finder)
     ->setCacheFile(__DIR__.'/.php-cs-fixer.cache')
 ;


### PR DESCRIPTION
With this line i do not get the line-ending warnings if i run 
`vendor/bin/php-cs-fixer fix  --dry-run --format checkstyle`
I am using Mac.

example:
`  <file name="tests/Routing/RouteLoaderTest.php">
    <error severity="warning" source="PHP-CS-Fixer.line_ending" message="Found violation(s) of type: line_ending"/>
  </file>
`

And if i run the actual command i not have to watch out for commits everytime (and do it in 2 commands) or with manuel work.
`vendor/bin/php-cs-fixer fix --format checkstyle`

Please check this on your pc.