### PR TITLE
ci: Add testruns for PHP 8.3

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -82,7 +82,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php-versions: ['8.1', '8.2']
+                php-versions: ['8.1', '8.2', '8.3', '8.4']
             fail-fast: false
         name: PHP ${{ matrix.php-versions }} tests
         steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -82,7 +82,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php-versions: ['8.1', '8.2', '8.3', '8.4']
+                php-versions: ['8.1', '8.2', '8.3']
             fail-fast: false
         name: PHP ${{ matrix.php-versions }} tests
         steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -82,7 +82,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php-versions: ['8.1', '8.2', '8.3']
+                php-versions: ['8.1', '8.2', '8.3', '8.4']
             fail-fast: false
         name: PHP ${{ matrix.php-versions }} tests
         steps:

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
     "symfony/framework-bundle": "^6.4|^7.0",
     "symfony/phpunit-bridge": "^6.4|^7.0",
     "symfony/yaml": "^6.4|^7.0",
-    "vimeo/psalm": "^5.26",
+    "vimeo/psalm": "^5.26|^6.0",
     "willdurand/negotiation": "^3.0"
   },
   "config": {


### PR DESCRIPTION
PHP 8.4 needs to wait until vimeo/psalm supports it.
But wen can add testruns for PHP 8.3