### PR TITLE
Use GET to validate api resource existence

### DIFF
--- a/src/ApiResource/ExistenceChecker.php
+++ b/src/ApiResource/ExistenceChecker.php
@@ -32,6 +32,8 @@ class ExistenceChecker implements ReplaceableHttpClientInterface
         private readonly MicroservicePool $microservices,
     ) {
         $this->httpClient = $httpClient;
+
+        trigger_deprecation('mtarld/api-platform-ms-bundle', '1.3.0', sprintf('%s is deprecated.', self::class));
     }
 
     /**

--- a/src/ApiResource/ExistenceVerifier.php
+++ b/src/ApiResource/ExistenceVerifier.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Mtarld\ApiPlatformMsBundle\ApiResource;
+
+use Mtarld\ApiPlatformMsBundle\HttpClient\GenericHttpClient;
+use Mtarld\ApiPlatformMsBundle\HttpClient\ReplaceableHttpClientInterface;
+use Mtarld\ApiPlatformMsBundle\HttpClient\ReplaceableHttpClientTrait;
+use Mtarld\ApiPlatformMsBundle\Microservice\MicroservicePool;
+
+/**
+ * @final @internal
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+class ExistenceVerifier implements ReplaceableHttpClientInterface
+{
+    use ReplaceableHttpClientTrait;
+
+    public function __construct(
+        private GenericHttpClient $httpClient,
+        private readonly MicroservicePool $microservices,
+    ) {
+    }
+
+    public function verify(string $microserviceName, string $iri): bool
+    {
+        $response = $this->httpClient->request(
+            $this->microservices->get($microserviceName),
+            'GET',
+            $iri,
+        );
+
+        $statusCode = $response->getStatusCode();
+
+        if (200 <= $statusCode && 300 > $statusCode) {
+            return true;
+        }
+
+        if (404 === $statusCode) {
+            return false;
+        }
+
+        // make it throw
+        return (bool) $response->getContent(true);
+    }
+}

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -3,12 +3,14 @@
 namespace Mtarld\ApiPlatformMsBundle\DependencyInjection\Loader\Configurator;
 
 use Mtarld\ApiPlatformMsBundle\ApiResource\ExistenceChecker;
+use Mtarld\ApiPlatformMsBundle\ApiResource\ExistenceVerifier;
 use Mtarld\ApiPlatformMsBundle\Collection\PaginatedCollectionIterator;
 use Mtarld\ApiPlatformMsBundle\Controller\ApiResourceExistenceCheckerAction;
 use Mtarld\ApiPlatformMsBundle\EventListener\RequestLoggerListener;
 use Mtarld\ApiPlatformMsBundle\HttpClient\GenericHttpClient;
 use Mtarld\ApiPlatformMsBundle\Microservice\MicroservicePool;
 use Mtarld\ApiPlatformMsBundle\Routing\RouteLoader;
+use Mtarld\ApiPlatformMsBundle\Validator\ApiResourceExistsValidator;
 use Mtarld\ApiPlatformMsBundle\Validator\ApiResourceExistValidator;
 use Mtarld\ApiPlatformMsBundle\Validator\FormatEnabledValidator;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -54,9 +56,22 @@ return static function (ContainerConfigurator $container): void {
                 service('serializer'),
                 service('api_platform_ms.microservice_pool'),
             ])
+        ->set('api_platform_ms.api_resource.existence_verifier', ExistenceVerifier::class)
+            ->args([
+                service('api_platform_ms.http_client.generic'),
+                service('api_platform_ms.microservice_pool'),
+            ])
         ->set('api_platform_ms.validator.api_resource_exist', ApiResourceExistValidator::class)
             ->args([
                 service('api_platform_ms.api_resource.existence_checker'),
+            ])
+            ->call('setLogger', [
+                service('logger'),
+            ])
+            ->tag('validator.constraint_validator')
+        ->set('api_platform_ms.validator.api_resource_exists', ApiResourceExistsValidator::class)
+            ->args([
+                service('api_platform_ms.api_resource.existence_verifier'),
             ])
             ->call('setLogger', [
                 service('logger'),

--- a/src/Resources/doc/tools/existence-constraint.md
+++ b/src/Resources/doc/tools/existence-constraint.md
@@ -4,23 +4,26 @@ Sometimes, resources of a microservice A depends on resource of a microservice B
 Then you may need to ensure that related resources are existing when validating a resource.
 
 ## Description
-The `ApiResourceExist` constraint helps you to ensure that the related resources are existing on the other microservice
+The `ApiResourceExists` constraint helps you to ensure that the related resource exists on the other microservice
 when doing validation.
-It can verify either IRIs and list of IRIs.
 
 ## Example
 ```php
-use Mtarld\ApiPlatformMsBundle\Validator\ApiResourceExist;
+use Mtarld\ApiPlatformMsBundle\Validator\ApiResourceExists;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class Order
 {
     /**
      * @var list<string>
      */
-    #[ApiResourceExist('product')]
+    #[Assert\All([
+        new Assert\NotBlank(allowNull: false),
+        new ApiResourceExists('product', regexPattern: '/^\/api\/products\/\d+$/'),
+    ])]
     public array $products;
 
-    #[ApiResourceExist(microservice: 'client', skipOnError: true)]
+    #[ApiResourceExists(microservice: 'client', skipOnError: true)]
     public string $customer;
 }
 ```

--- a/src/Validator/ApiResourceExist.php
+++ b/src/Validator/ApiResourceExist.php
@@ -58,6 +58,8 @@ final class ApiResourceExist extends Constraint
 
         $this->message = $message ?? $this->message;
         $this->skipOnError = $skipOnError ?? $this->skipOnError;
+
+        trigger_deprecation('mtarld/api-platform-ms-bundle', '1.3.0', sprintf('%s is deprecated, use %s instead.', self::class, ApiResourceExists::class));
     }
 
     public function getDefaultOption(): string

--- a/src/Validator/ApiResourceExists.php
+++ b/src/Validator/ApiResourceExists.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Mtarld\ApiPlatformMsBundle\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
+final class ApiResourceExists extends Constraint
+{
+    public const IRI_NOT_FOUND_ERROR = 'f0bcb756-1ca0-4611-bd68-84286ed1525e';
+
+    protected const ERROR_NAMES = [
+        self::IRI_NOT_FOUND_ERROR => 'IRI_NOT_FOUND_ERROR',
+    ];
+
+    /**
+     * @param string $microservice The name of the target microservice
+     * @param bool   $skipOnError  Skip validation on HTTP errors
+     * @param string $regexPattern The regex pattern which an IRI must match
+     *
+     * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     */
+    public function __construct(
+        public string $microservice,
+        public bool $skipOnError = false,
+        public string $regexPattern = '/^\/[\w-]+(\/[\w-]+)+$/',
+        public string $message = "'{{ iri }}' does not exist in microservice '{{ microservice }}'",
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
+}

--- a/src/Validator/ApiResourceExistsValidator.php
+++ b/src/Validator/ApiResourceExistsValidator.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Mtarld\ApiPlatformMsBundle\Validator;
+
+use Mtarld\ApiPlatformMsBundle\ApiResource\ExistenceVerifier;
+use Psr\Log\LoggerAwareTrait;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
+
+/**
+ * @psalm-suppress PropertyNotSetInConstructor
+ */
+final class ApiResourceExistsValidator extends ConstraintValidator
+{
+    use LoggerAwareTrait;
+
+    public function __construct(
+        private readonly ExistenceVerifier $existenceVerifier,
+    ) {
+    }
+
+    #[\Override]
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof ApiResourceExists) {
+            throw new UnexpectedTypeException($constraint, ApiResourceExists::class);
+        }
+
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        $currentViolations = count($this->context->getViolations());
+
+        $this->checkPreconstraints($value, $constraint);
+
+        if ($currentViolations === count($this->context->getViolations())) {
+            try {
+                if (!$this->existenceVerifier->verify($constraint->microservice, $value)) {
+                    $this->context->buildViolation($constraint->message)
+                        ->setParameter('{{ iri }}', $value)
+                        ->setParameter('{{ microservice }}', $constraint->microservice)
+                        ->setCode(ApiResourceExists::IRI_NOT_FOUND_ERROR)
+                        ->addViolation()
+                    ;
+                }
+            } catch (ExceptionInterface $e) {
+                $this->handleHttpException($e, $constraint);
+            }
+        }
+    }
+
+    private function checkPreconstraints(mixed $value, ApiResourceExists $constraint): void
+    {
+        $constraints = [
+            new Assert\Regex(pattern: $constraint->regexPattern),
+        ];
+        $validator = $this->context->getValidator()->inContext($this->context);
+
+        $validator->validate($value, $constraints);
+    }
+
+    private function handleHttpException(ExceptionInterface $exception, ApiResourceExists $constraint): void
+    {
+        $message = sprintf(
+            "Unable to validate IRIs of microservice '%s': %s",
+            $constraint->microservice,
+            $exception->getMessage()
+        );
+
+        $this->logger?->debug($message);
+
+        if ($constraint->skipOnError) {
+            return;
+        }
+
+        throw new \RuntimeException($message);
+    }
+}

--- a/tests/ApiResource/ExistenceCheckerTest.php
+++ b/tests/ApiResource/ExistenceCheckerTest.php
@@ -12,6 +12,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 /**
  * @group resource-existence
  * @group http
+ * @group legacy
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  */

--- a/tests/ApiResource/ExistenceVerifierTest.php
+++ b/tests/ApiResource/ExistenceVerifierTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Mtarld\ApiPlatformMsBundle\Tests\ApiResource;
+
+use Mtarld\ApiPlatformMsBundle\Exception\MicroserviceNotConfiguredException;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * @group resource-existence
+ * @group http
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+final class ExistenceVerifierTest extends KernelTestCase
+{
+    public function testMicroserviceNotConfigured(): void
+    {
+        $this->expectException(MicroserviceNotConfiguredException::class);
+
+        self::getContainer()->get('test.existence_verifier')->verify('foo', '/api/products/1');
+    }
+
+    public function testCallOtherMicroservice(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response
+            ->method('getStatusCode')
+            ->willReturn(200)
+        ;
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient
+            ->expects(self::once())
+            ->method('request')
+            ->with(
+                'GET',
+                '/api/products/1',
+                [
+                    'base_uri' => 'https://localhost',
+                    'headers' => [
+                        'Accept' => 'application/ld+json',
+                        'Content-Type' => 'application/ld+json',
+                    ],
+                ],
+            )
+            ->willReturn($response)
+        ;
+
+        self::getContainer()->set('test.http_client', $httpClient);
+        self::getContainer()->get('api_platform_ms.api_resource.existence_verifier')->verify('bar', '/api/products/1');
+    }
+
+    /**
+     * @dataProvider provideSuccessStatusCodes
+     */
+    public function testParseSuccessfulMicroserviceResponse(int $statusCode): void
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse(info: ['http_code' => $statusCode]),
+        ]);
+        self::getContainer()->set('test.http_client', $httpClient);
+
+        self::assertTrue(
+            self::getContainer()->get('api_platform_ms.api_resource.existence_verifier')->verify('bar', '/api/products/1'),
+        );
+    }
+
+    public static function provideSuccessStatusCodes(): iterable
+    {
+        yield [200];
+        yield [203];
+    }
+
+    public function testParseNotFoundMicroserviceResponse(): void
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse(info: ['http_code' => 404]),
+        ]);
+        self::getContainer()->set('test.http_client', $httpClient);
+
+        self::assertFalse(
+            self::getContainer()->get('api_platform_ms.api_resource.existence_verifier')->verify('bar', '/api/products/1'),
+        );
+    }
+
+    public function testErroredMicroserviceResponse(): void
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse(info: ['http_code' => 500]),
+        ]);
+
+        $this->expectException(\Throwable::class);
+
+        self::getContainer()->set('test.http_client', $httpClient);
+        self::getContainer()->get('api_platform_ms.api_resource.existence_verifier')->verify('bar', '/api/products/1');
+    }
+
+    public function testSwitchHttpClient(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+
+        $firstHttpClient = $this->createMock(HttpClientInterface::class);
+        $firstHttpClient->expects(self::once())->method('request')->willReturn($response);
+
+        $secondHttpClient = $this->createMock(HttpClientInterface::class);
+        $secondHttpClient->expects(self::once())->method('request')->willReturn($response);
+
+        self::getContainer()->set('test.http_client', $firstHttpClient);
+
+        $existenceVerifier = self::getContainer()->get('api_platform_ms.api_resource.existence_verifier');
+        $existenceVerifier->verify('bar', '/api/products/1');
+
+        $existenceVerifier->setWrappedHttpClient($secondHttpClient);
+        $existenceVerifier->verify('bar', '/api/products/1');
+    }
+}

--- a/tests/Fixtures/App/config/config.yml
+++ b/tests/Fixtures/App/config/config.yml
@@ -57,6 +57,9 @@ services:
   test.existence_checker:
     alias: api_platform_ms.api_resource.existence_checker
 
+  test.existence_verifier:
+    alias: api_platform_ms.api_resource.existence_verifier
+
   test.http_client:
     alias: api_platform_ms.http_client
 

--- a/tests/Validator/ApiResourceExistValidatorTest.php
+++ b/tests/Validator/ApiResourceExistValidatorTest.php
@@ -14,6 +14,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 /**
  * @group resource-existence
  * @group validator
+ * @group legacy
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  */

--- a/tests/Validator/ApiResourceExistsValidatorTest.php
+++ b/tests/Validator/ApiResourceExistsValidatorTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mtarld\ApiPlatformMsBundle\Tests\Validator;
+
+use Mtarld\ApiPlatformMsBundle\ApiResource\ExistenceVerifier;
+use Mtarld\ApiPlatformMsBundle\Validator\ApiResourceExists;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Validator\Constraints\Regex;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+final class ApiResourceExistsValidatorTest extends KernelTestCase
+{
+    /**
+     * @dataProvider provideBlankIris
+     */
+    public function testDoNothingWhenNullOrEmpty(?string $iri): void
+    {
+        $validator = self::getContainer()->get(ValidatorInterface::class);
+        $existenceVerifier = $this->createMock(ExistenceVerifier::class);
+        $existenceVerifier->expects(self::never())->method('verify');
+        self::getContainer()->set('test.existence_verifier', $existenceVerifier);
+
+        $violations = $validator->validate($iri, new ApiResourceExists('bar'));
+
+        self::assertCount(0, $violations);
+    }
+
+    public static function provideBlankIris(): iterable
+    {
+        yield 'null' => [null];
+        yield 'empty' => [''];
+    }
+
+    /**
+     * @dataProvider provideInvalidIris
+     */
+    public function testDoNotCallRemoteWhenInvalidIri(int|string|null $invalidIri): void
+    {
+        $existenceVerifier = $this->createMock(ExistenceVerifier::class);
+        $existenceVerifier->expects(self::never())->method('verify');
+
+        self::getContainer()->set('test.existence_verifier', $existenceVerifier);
+        self::getContainer()->get(ValidatorInterface::class)->validate($invalidIri, new ApiResourceExists('bar'));
+    }
+
+    public static function provideInvalidIris(): iterable
+    {
+        yield ['   '];
+        yield ['/api'];
+        yield [2];
+    }
+
+    /**
+     * @dataProvider provideInvalidIris
+     */
+    public function testViolationsWhenInvalidIri(int|string|null $invalidIri): void
+    {
+        $validator = self::getContainer()->get(ValidatorInterface::class);
+        $violations = $validator->validate($invalidIri, new ApiResourceExists('bar'));
+
+        self::assertCount(1, $violations);
+        self::assertSame($invalidIri, $violations->get(0)->getInvalidValue());
+        self::assertSame(Regex::REGEX_FAILED_ERROR, $violations->get(0)->getCode());
+    }
+
+    public function testViolationsWhenApiResourceNotFound(): void
+    {
+        $existenceVerifier = $this->createMock(ExistenceVerifier::class);
+        $existenceVerifier->method('verify')->willReturn(false);
+        self::getContainer()->set('test.existence_verifier', $existenceVerifier);
+
+        $validator = self::getContainer()->get(ValidatorInterface::class);
+        $violations = $validator->validate('/api/products/1', new ApiResourceExists('bar'));
+
+        self::assertCount(1, $violations);
+        self::assertSame("'/api/products/1' does not exist in microservice 'bar'", $violations->get(0)->getMessage());
+        self::assertSame('/api/products/1', $violations->get(0)->getInvalidValue());
+        self::assertSame(ApiResourceExists::IRI_NOT_FOUND_ERROR, $violations->get(0)->getCode());
+    }
+
+    public function testLogOnHttpException(): void
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse(info: ['http_code' => 500]),
+        ]);
+        self::getContainer()->set('test.http_client', $httpClient);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
+            ->expects(self::once())
+            ->method('debug')
+            ->with("Unable to validate IRIs of microservice 'bar': HTTP 500 returned for \"https://localhost/api/products/1\".")
+        ;
+        self::getContainer()->set('test.logger', $logger);
+
+        self::getContainer()->get(ValidatorInterface::class)->validate(
+            '/api/products/1',
+            new ApiResourceExists('bar', true),
+        );
+    }
+
+    public function testSkipOnError(): void
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse(info: ['http_code' => 500]),
+            new MockResponse(info: ['http_code' => 500]),
+        ]);
+        self::getContainer()->set('test.http_client', $httpClient);
+
+        $violations = self::getContainer()->get(ValidatorInterface::class)->validate(
+            '/api/products/1',
+            new ApiResourceExists('bar', true)
+        );
+        self::assertCount(0, $violations);
+
+        $this->expectException(\RuntimeException::class);
+        self::getContainer()->get(ValidatorInterface::class)->validate(
+            '/api/products/1',
+            new ApiResourceExists('bar')
+        );
+    }
+}


### PR DESCRIPTION
This PR does the following:

- adds a new existence verifier using GET requests to verify api resource existence in contrast to the current custom POST endpoint and deprecates the current existence checker
- adds a new idiomatic `ApiResourceExists` validation constraint and deprecates `ApiResourceExist`

Closes #92 