### PR TITLE
House keeping

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,7 +14,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: '8.2'
+                  php-version: '8.3'
                   tools: php-cs-fixer, cs2pr
 
             - name: PHP Coding Standards Fixer
@@ -30,7 +30,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: '8.2'
+                  php-version: '8.4'
 
             - name: Get composer cache directory
               id: composercache
@@ -59,7 +59,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: '8.2'
+                  php-version: '8.4'
 
             - name: Get composer cache directory
               id: composercache

--- a/composer.json
+++ b/composer.json
@@ -44,14 +44,14 @@
     "doctrine/inflector": "^2.0",
     "friendsofphp/php-cs-fixer": "^3.1",
     "phpmd/phpmd": "^2.8",
-    "phpunit/phpunit": "^9.5",
+    "phpunit/phpunit": "^9.6.22",
     "psalm/plugin-phpunit": "^0.19",
     "rector/rector": "^2.0",
     "symfony/browser-kit": "^6.4|^7.0",
     "symfony/framework-bundle": "^6.4|^7.0",
     "symfony/phpunit-bridge": "^6.4|^7.0",
     "symfony/yaml": "^6.4|^7.0",
-    "vimeo/psalm": "^5.26|^6.0",
+    "vimeo/psalm": "^6.0",
     "willdurand/negotiation": "^3.0"
   },
   "config": {

--- a/psalm-baseline-symfony-64.xml
+++ b/psalm-baseline-symfony-64.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="6.10.1@f9fd6bc117e9ce1e854c2ed6777e7135aaa4966b">
+  <file src="src/Serializer/AbstractApiResourceDenormalizer.php">
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function getSupportedTypes(?string $format): array]]></code>
+    </MissingOverrideAttribute>
+  </file>
+  <file src="src/Serializer/AbstractCollectionDenormalizer.php">
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function getSupportedTypes(?string $format): array]]></code>
+    </MissingOverrideAttribute>
+  </file>
+  <file src="src/Serializer/AbstractConstraintViolationListDenormalizer.php">
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function getSupportedTypes(?string $format): array]]></code>
+    </MissingOverrideAttribute>
+  </file>
+  <file src="src/Serializer/Hal/ObjectDenormalizer.php">
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function getSupportedTypes(?string $format): array]]></code>
+    </MissingOverrideAttribute>
+  </file>
+  <file src="src/Serializer/JsonApi/ObjectDenormalizer.php">
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function getSupportedTypes(?string $format): array]]></code>
+    </MissingOverrideAttribute>
+  </file>
+</files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -7,6 +7,7 @@
     findUnusedBaselineEntry="true"
     findUnusedCode="false"
     resolveFromConfigFile="true"
+    errorBaseline="psalm-baseline-symfony-64.xml"
 >
     <projectFiles>
         <directory name="src"/>
@@ -16,20 +17,6 @@
             <directory name="vendor"/>
         </ignoreFiles>
     </projectFiles>
-
-    <issueHandlers>
-        <InternalMethod>
-            <errorLevel type="suppress">
-                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::willReturn" />
-                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::willReturnCallback" />
-                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::method" />
-                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::willReturnOnConsecutiveCalls" />
-                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::with" />
-                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::will" />
-                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::withConsecutive" />
-            </errorLevel>
-        </InternalMethod>
-    </issueHandlers>
 
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>

--- a/src/ApiPlatformMsBundle.php
+++ b/src/ApiPlatformMsBundle.php
@@ -16,6 +16,7 @@ class_exists(CreateHttpClientsPass::class);
  */
 class ApiPlatformMsBundle extends Bundle
 {
+    #[\Override]
     public function build(ContainerBuilder $container): void
     {
         parent::build($container);

--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -44,11 +44,13 @@ class Collection implements \IteratorAggregate, \Countable
     /**
      * @return \Iterator<T>
      */
+    #[\Override]
     public function getIterator(): \Iterator
     {
         return new \ArrayIterator($this->elements);
     }
 
+    #[\Override]
     public function count(): int
     {
         return $this->count;

--- a/src/DependencyInjection/ApiPlatformMsExtension.php
+++ b/src/DependencyInjection/ApiPlatformMsExtension.php
@@ -27,6 +27,7 @@ class ApiPlatformMsExtension extends Extension
         'jsonhal' => 'hal.php',
     ];
 
+    #[\Override]
     public function getAlias(): string
     {
         return 'api_platform_ms';
@@ -35,6 +36,7 @@ class ApiPlatformMsExtension extends Extension
     /**
      * @param array<array-key, mixed> $configs
      */
+    #[\Override]
     public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new PhpFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
@@ -78,6 +80,7 @@ class ApiPlatformMsExtension extends Extension
     /**
      * @SuppressWarnings(UnusedFormalParameter)
      */
+    #[\Override]
     public function getConfiguration(array $config, ContainerBuilder $container): ?ConfigurationInterface
     {
         /** @var bool $debug */

--- a/src/DependencyInjection/Compiler/CreateHttpClientsPass.php
+++ b/src/DependencyInjection/Compiler/CreateHttpClientsPass.php
@@ -15,6 +15,7 @@ class_exists(MicroserviceHttpClient::class);
  */
 class CreateHttpClientsPass implements CompilerPassInterface
 {
+    #[\Override]
     public function process(ContainerBuilder $container): void
     {
         /** @var array<string, array> $microservices */

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -20,6 +20,7 @@ class Configuration implements ConfigurationInterface
     {
     }
 
+    #[\Override]
     public function getConfigTreeBuilder(): TreeBuilder
     {
         $builder = new TreeBuilder('api_platform_ms');

--- a/src/HttpClient/GenericHttpClient.php
+++ b/src/HttpClient/GenericHttpClient.php
@@ -85,6 +85,7 @@ class GenericHttpClient implements ReplaceableHttpClientInterface
         return $response;
     }
 
+    #[\Override]
     public function setWrappedHttpClient(HttpClientInterface $httpClient): void
     {
         $this->httpClient = $httpClient;

--- a/src/HttpClient/MicroserviceHttpClient.php
+++ b/src/HttpClient/MicroserviceHttpClient.php
@@ -25,7 +25,7 @@ class MicroserviceHttpClient implements MicroserviceHttpClientInterface
     }
 
     #[\Override]
-    public function request(string $method, string $uri, $body = null, ?string $mimeType = null, ?string $bodyFormat = null): ResponseInterface
+    public function request(string $method, string $uri, mixed $body = null, ?string $mimeType = null, ?string $bodyFormat = null): ResponseInterface
     {
         return $this->httpClient->request($this->microservices->get($this->microserviceName), $method, $uri, $body, $mimeType, $bodyFormat);
     }

--- a/src/HttpClient/MicroserviceHttpClient.php
+++ b/src/HttpClient/MicroserviceHttpClient.php
@@ -24,6 +24,7 @@ class MicroserviceHttpClient implements MicroserviceHttpClientInterface
         $this->httpClient = $httpClient;
     }
 
+    #[\Override]
     public function request(string $method, string $uri, $body = null, ?string $mimeType = null, ?string $bodyFormat = null): ResponseInterface
     {
         return $this->httpClient->request($this->microservices->get($this->microserviceName), $method, $uri, $body, $mimeType, $bodyFormat);

--- a/src/HttpClient/MicroserviceHttpClientInterface.php
+++ b/src/HttpClient/MicroserviceHttpClientInterface.php
@@ -13,5 +13,5 @@ interface MicroserviceHttpClientInterface extends ReplaceableHttpClientInterface
     /**
      * @throws HttpExceptionInterface
      */
-    public function request(string $method, string $uri, mixed $body = null, string $mimeType = null, string $bodyFormat = null): ResponseInterface;
+    public function request(string $method, string $uri, mixed $body = null, ?string $mimeType = null, ?string $bodyFormat = null): ResponseInterface;
 }

--- a/src/Microservice/MicroservicePool.php
+++ b/src/Microservice/MicroservicePool.php
@@ -46,6 +46,7 @@ class MicroservicePool implements \IteratorAggregate
         return $this->microservices[$name];
     }
 
+    #[\Override]
     public function getIterator(): \Traversable
     {
         foreach (array_keys($this->configs) as $name) {

--- a/src/Serializer/AbstractApiResourceDenormalizer.php
+++ b/src/Serializer/AbstractApiResourceDenormalizer.php
@@ -33,6 +33,7 @@ abstract class AbstractApiResourceDenormalizer implements DenormalizerInterface,
     /**
      * @throws ExceptionInterface
      */
+    #[\Override]
     public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
     {
         $iri = $this->getIri($data);
@@ -43,6 +44,7 @@ abstract class AbstractApiResourceDenormalizer implements DenormalizerInterface,
         return $this->denormalizer->denormalize($data, $type, $this->getFormat());
     }
 
+    #[\Override]
     public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
     {
         return

--- a/src/Serializer/AbstractApiResourceDenormalizer.php
+++ b/src/Serializer/AbstractApiResourceDenormalizer.php
@@ -34,7 +34,7 @@ abstract class AbstractApiResourceDenormalizer implements DenormalizerInterface,
      * @throws ExceptionInterface
      */
     #[\Override]
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         $iri = $this->getIri($data);
         $data = $this->prepareEmbeddedData($data);
@@ -45,7 +45,7 @@ abstract class AbstractApiResourceDenormalizer implements DenormalizerInterface,
     }
 
     #[\Override]
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return
             !isset($data['iri'])

--- a/src/Serializer/AbstractCollectionDenormalizer.php
+++ b/src/Serializer/AbstractCollectionDenormalizer.php
@@ -38,6 +38,7 @@ abstract class AbstractCollectionDenormalizer implements DenormalizerInterface, 
     /**
      * @return Collection<object>
      */
+    #[\Override]
     public function denormalize(mixed $data, string $type, string $format = null, array $context = []): Collection
     {
         if ($this->isRawCollection($data)) {
@@ -55,6 +56,7 @@ abstract class AbstractCollectionDenormalizer implements DenormalizerInterface, 
      * @param string $type
      * @param string $format
      */
+    #[\Override]
     public function supportsDenormalization(mixed $data, $type, $format = null, array $context = []): bool
     {
         if ($this->getFormat() !== $format) {

--- a/src/Serializer/AbstractCollectionDenormalizer.php
+++ b/src/Serializer/AbstractCollectionDenormalizer.php
@@ -39,7 +39,7 @@ abstract class AbstractCollectionDenormalizer implements DenormalizerInterface, 
      * @return Collection<object>
      */
     #[\Override]
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): Collection
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): Collection
     {
         if ($this->isRawCollection($data)) {
             return new Collection($elements = $this->denormalizeRawElements($data, $this->getEnclosedType($type), $context), count($elements));
@@ -52,12 +52,8 @@ abstract class AbstractCollectionDenormalizer implements DenormalizerInterface, 
         );
     }
 
-    /**
-     * @param string $type
-     * @param string $format
-     */
     #[\Override]
-    public function supportsDenormalization(mixed $data, $type, $format = null, array $context = []): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         if ($this->getFormat() !== $format) {
             return false;

--- a/src/Serializer/AbstractConstraintViolationListDenormalizer.php
+++ b/src/Serializer/AbstractConstraintViolationListDenormalizer.php
@@ -32,13 +32,13 @@ abstract class AbstractConstraintViolationListDenormalizer implements Denormaliz
      * @psalm-suppress MoreSpecificImplementedParamType
      */
     #[\Override]
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): ConstraintViolationList
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): ConstraintViolationList
     {
         return new ConstraintViolationList(array_map(fn (array $violation): ConstraintViolation => $this->denormalizeViolation($violation), $data[$this->getViolationsKey()]));
     }
 
     #[\Override]
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return ConstraintViolationList::class === $type && $this->getFormat() === $format;
     }

--- a/src/Serializer/AbstractConstraintViolationListDenormalizer.php
+++ b/src/Serializer/AbstractConstraintViolationListDenormalizer.php
@@ -31,11 +31,13 @@ abstract class AbstractConstraintViolationListDenormalizer implements Denormaliz
      *
      * @psalm-suppress MoreSpecificImplementedParamType
      */
+    #[\Override]
     public function denormalize(mixed $data, string $type, string $format = null, array $context = []): ConstraintViolationList
     {
         return new ConstraintViolationList(array_map(fn (array $violation): ConstraintViolation => $this->denormalizeViolation($violation), $data[$this->getViolationsKey()]));
     }
 
+    #[\Override]
     public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
     {
         return ConstraintViolationList::class === $type && $this->getFormat() === $format;

--- a/src/Serializer/Hal/ApiResourceDenormalizer.php
+++ b/src/Serializer/Hal/ApiResourceDenormalizer.php
@@ -13,16 +13,19 @@ class ApiResourceDenormalizer extends AbstractApiResourceDenormalizer
 {
     use HalDenormalizerTrait;
 
+    #[\Override]
     protected function getIri(array $data): string
     {
         return $data['_links']['self']['href'];
     }
 
+    #[\Override]
     protected function prepareData(array $data): array
     {
         return $data;
     }
 
+    #[\Override]
     protected function prepareEmbeddedData(array $data): array
     {
         if (!isset($data['_links'], $data['_embedded'])) {

--- a/src/Serializer/Hal/CollectionDenormalizer.php
+++ b/src/Serializer/Hal/CollectionDenormalizer.php
@@ -20,6 +20,7 @@ class CollectionDenormalizer extends AbstractCollectionDenormalizer
     /**
      * @return array<object>
      */
+    #[\Override]
     protected function denormalizeElements(array $data, string $enclosedType, array $context): array
     {
         return array_map(function (array $elementData) use ($enclosedType, $context) {
@@ -30,11 +31,13 @@ class CollectionDenormalizer extends AbstractCollectionDenormalizer
         }, $data['_embedded']['item']);
     }
 
+    #[\Override]
     protected function getTotalItems(array $data): int
     {
         return $data['totalItems'];
     }
 
+    #[\Override]
     protected function getPagination(array $data): ?Pagination
     {
         return array_key_exists('first', $links = $data['_links'])
@@ -48,6 +51,7 @@ class CollectionDenormalizer extends AbstractCollectionDenormalizer
             : null;
     }
 
+    #[\Override]
     protected function isRawCollection(array $data): bool
     {
         return !array_key_exists('_embedded', $data);

--- a/src/Serializer/Hal/ConstraintViolationListDenormalizer.php
+++ b/src/Serializer/Hal/ConstraintViolationListDenormalizer.php
@@ -17,11 +17,13 @@ class ConstraintViolationListDenormalizer extends AbstractConstraintViolationLis
 {
     use HalDenormalizerTrait;
 
+    #[\Override]
     protected function getViolationsKey(): string
     {
         return 'violations';
     }
 
+    #[\Override]
     protected function denormalizeViolation(array $data): ConstraintViolation
     {
         return new ConstraintViolation(

--- a/src/Serializer/Hal/ObjectDenormalizer.php
+++ b/src/Serializer/Hal/ObjectDenormalizer.php
@@ -18,11 +18,13 @@ class ObjectDenormalizer implements DenormalizerInterface, DenormalizerAwareInte
     use HalDenormalizerTrait;
     use DenormalizerAwareTrait;
 
+    #[\Override]
     public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
     {
         return $this->denormalizer->denormalize($data, $type, 'json', $context);
     }
 
+    #[\Override]
     public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
     {
         return $this->getFormat() === $format;

--- a/src/Serializer/Hal/ObjectDenormalizer.php
+++ b/src/Serializer/Hal/ObjectDenormalizer.php
@@ -19,13 +19,13 @@ class ObjectDenormalizer implements DenormalizerInterface, DenormalizerAwareInte
     use DenormalizerAwareTrait;
 
     #[\Override]
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         return $this->denormalizer->denormalize($data, $type, 'json', $context);
     }
 
     #[\Override]
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return $this->getFormat() === $format;
     }

--- a/src/Serializer/Hydra/ApiResourceDenormalizer.php
+++ b/src/Serializer/Hydra/ApiResourceDenormalizer.php
@@ -13,16 +13,19 @@ class ApiResourceDenormalizer extends AbstractApiResourceDenormalizer
 {
     use HydraDenormalizerTrait;
 
+    #[\Override]
     protected function getIri(array $data): string
     {
         return $data['@id'];
     }
 
+    #[\Override]
     protected function prepareData(array $data): array
     {
         return $data;
     }
 
+    #[\Override]
     protected function prepareEmbeddedData(array $data): array
     {
         return $data;

--- a/src/Serializer/Hydra/CollectionDenormalizer.php
+++ b/src/Serializer/Hydra/CollectionDenormalizer.php
@@ -17,6 +17,7 @@ class CollectionDenormalizer extends AbstractCollectionDenormalizer
 {
     use HydraDenormalizerTrait;
 
+    #[\Override]
     protected function denormalizeElements(array $data, string $enclosedType, array $context): array
     {
         return array_map(function (array $elementData) use ($enclosedType, $context) {
@@ -27,11 +28,13 @@ class CollectionDenormalizer extends AbstractCollectionDenormalizer
         }, $data['hydra:member'] ?? $data['member']);
     }
 
+    #[\Override]
     protected function getTotalItems(array $data): int
     {
         return $data['hydra:totalItems'] ?? $data['totalItems'];
     }
 
+    #[\Override]
     protected function getPagination(array $data): ?Pagination
     {
         $view = $data['hydra:view'] ?? $data['view'] ?? [];
@@ -47,6 +50,7 @@ class CollectionDenormalizer extends AbstractCollectionDenormalizer
             : null;
     }
 
+    #[\Override]
     protected function isRawCollection(array $data): bool
     {
         return !array_key_exists('@type', $data);

--- a/src/Serializer/Hydra/ConstraintViolationListDenormalizer.php
+++ b/src/Serializer/Hydra/ConstraintViolationListDenormalizer.php
@@ -17,11 +17,13 @@ class ConstraintViolationListDenormalizer extends AbstractConstraintViolationLis
 {
     use HydraDenormalizerTrait;
 
+    #[\Override]
     protected function getViolationsKey(): string
     {
         return 'violations';
     }
 
+    #[\Override]
     protected function denormalizeViolation(array $data): ConstraintViolation
     {
         return new ConstraintViolation(

--- a/src/Serializer/JsonApi/ApiResourceDenormalizer.php
+++ b/src/Serializer/JsonApi/ApiResourceDenormalizer.php
@@ -13,11 +13,13 @@ class ApiResourceDenormalizer extends AbstractApiResourceDenormalizer
 {
     use JsonApiDenormalizerTrait;
 
+    #[\Override]
     protected function getIri(array $data): string
     {
         return $data['data']['id'];
     }
 
+    #[\Override]
     protected function prepareData(array $data): array
     {
         return $data['data']['attributes'];
@@ -28,6 +30,7 @@ class ApiResourceDenormalizer extends AbstractApiResourceDenormalizer
      *
      * @psalm-suppress MoreSpecificImplementedParamType
      */
+    #[\Override]
     protected function prepareEmbeddedData(array $data): array
     {
         if (!isset($data['data']['relationships'], $data['included'])) {

--- a/src/Serializer/JsonApi/CollectionDenormalizer.php
+++ b/src/Serializer/JsonApi/CollectionDenormalizer.php
@@ -20,6 +20,7 @@ class CollectionDenormalizer extends AbstractCollectionDenormalizer
     /**
      * @return array<object>
      */
+    #[\Override]
     protected function denormalizeElements(array $data, string $enclosedType, array $context): array
     {
         return array_map(function (array $elementData) use ($enclosedType, $context) {
@@ -30,11 +31,13 @@ class CollectionDenormalizer extends AbstractCollectionDenormalizer
         }, $data['data']);
     }
 
+    #[\Override]
     protected function getTotalItems(array $data): int
     {
         return $data['meta']['totalItems'];
     }
 
+    #[\Override]
     protected function getPagination(array $data): ?Pagination
     {
         return !empty($data['links']['first'] ?? null)
@@ -48,6 +51,7 @@ class CollectionDenormalizer extends AbstractCollectionDenormalizer
             : null;
     }
 
+    #[\Override]
     protected function isRawCollection(array $data): bool
     {
         return !array_key_exists('data', $data);

--- a/src/Serializer/JsonApi/ConstraintViolationListDenormalizer.php
+++ b/src/Serializer/JsonApi/ConstraintViolationListDenormalizer.php
@@ -17,11 +17,13 @@ class ConstraintViolationListDenormalizer extends AbstractConstraintViolationLis
 {
     use JsonApiDenormalizerTrait;
 
+    #[\Override]
     protected function getViolationsKey(): string
     {
         return 'errors';
     }
 
+    #[\Override]
     protected function denormalizeViolation(array $data): ConstraintViolation
     {
         $pointerParts = explode('/', (string) $data['source']['pointer']);

--- a/src/Serializer/JsonApi/ObjectDenormalizer.php
+++ b/src/Serializer/JsonApi/ObjectDenormalizer.php
@@ -25,7 +25,7 @@ class ObjectDenormalizer implements DenormalizerInterface, DenormalizerAwareInte
     private const ALREADY_CALLED = 'jsonapi_object_denormalizer_already_called';
 
     #[\Override]
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         $context[self::ALREADY_CALLED] = true;
 
@@ -43,7 +43,7 @@ class ObjectDenormalizer implements DenormalizerInterface, DenormalizerAwareInte
     }
 
     #[\Override]
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return false === ($context[self::ALREADY_CALLED] ?? false) && $this->getFormat() === $format;
     }

--- a/src/Serializer/JsonApi/ObjectDenormalizer.php
+++ b/src/Serializer/JsonApi/ObjectDenormalizer.php
@@ -24,6 +24,7 @@ class ObjectDenormalizer implements DenormalizerInterface, DenormalizerAwareInte
 
     private const ALREADY_CALLED = 'jsonapi_object_denormalizer_already_called';
 
+    #[\Override]
     public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
     {
         $context[self::ALREADY_CALLED] = true;
@@ -41,6 +42,7 @@ class ObjectDenormalizer implements DenormalizerInterface, DenormalizerAwareInte
         return $this->denormalizer->denormalize($data, $type, $format, $context);
     }
 
+    #[\Override]
     public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
     {
         return false === ($context[self::ALREADY_CALLED] ?? false) && $this->getFormat() === $format;

--- a/src/Validator/ApiResourceExist.php
+++ b/src/Validator/ApiResourceExist.php
@@ -60,11 +60,13 @@ final class ApiResourceExist extends Constraint
         $this->skipOnError = $skipOnError ?? $this->skipOnError;
     }
 
+    #[\Override]
     public function getDefaultOption(): string
     {
         return 'microservice';
     }
 
+    #[\Override]
     public function getRequiredOptions(): array
     {
         return ['microservice'];

--- a/src/Validator/ApiResourceExistValidator.php
+++ b/src/Validator/ApiResourceExistValidator.php
@@ -34,6 +34,7 @@ class ApiResourceExistValidator extends ConstraintValidator
      *
      * @psalm-suppress MoreSpecificImplementedParamType
      */
+    #[\Override]
     public function validate($value, Constraint $constraint): void
     {
         if (!$constraint instanceof ApiResourceExist) {

--- a/src/Validator/FormatEnabledValidator.php
+++ b/src/Validator/FormatEnabledValidator.php
@@ -24,6 +24,7 @@ class FormatEnabledValidator extends ConstraintValidator
      *
      * @psalm-suppress MoreSpecificImplementedParamType
      */
+    #[\Override]
     public function validate($value, Constraint $constraint): void
     {
         if (!in_array($value, $this->enabledFormats, true)) {


### PR DESCRIPTION
Fixes static analysis and some deprecation warnings introduced by #91.

PHP-Cs-Fixer [installs on PHP 8.4]() but [runs up to PHP 8.3](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/7e33f7d79e50b57aa76542435d1c2705ec6da392/php-cs-fixer#L39).

Psalm has a [ClassMustBeFinal](https://psalm.dev/docs/running_psalm/issues/ClassMustBeFinal/) issue now, but this would you a BC break if I'd fix those, right?

I would look into migrating to phpunit 12 and address more psalm issues when time permits.