### PR TITLE
fix: do not denormalize ConstraintViolationList without the expected key

### DIFF
--- a/src/HttpRepository/AbstractMicroserviceHttpRepository.php
+++ b/src/HttpRepository/AbstractMicroserviceHttpRepository.php
@@ -131,8 +131,10 @@ abstract class AbstractMicroserviceHttpRepository implements ReplaceableHttpClie
 
             return $this->serializer->deserialize($response->getContent(), $this->getResourceDto(), $this->getMicroservice()->getFormat());
         } catch (ClientExceptionInterface $e) {
-            if ((400 === $e->getCode()) && null !== $violations = $this->createConstraintViolationListFromResponse($e->getResponse())) {
-                throw new ResourceValidationException($resource, $violations);
+            if (400 === $e->getCode() || 422 === $e->getCode()) {
+                if (null !== $violations = $this->createConstraintViolationListFromResponse($e->getResponse())) {
+                    throw new ResourceValidationException($resource, $violations);
+                }
             }
 
             throw $e;

--- a/src/Serializer/AbstractConstraintViolationListDenormalizer.php
+++ b/src/Serializer/AbstractConstraintViolationListDenormalizer.php
@@ -40,11 +40,11 @@ abstract class AbstractConstraintViolationListDenormalizer implements Denormaliz
     #[\Override]
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return ConstraintViolationList::class === $type && $this->getFormat() === $format;
+        return is_array($data) && array_key_exists($this->getViolationsKey(), $data);
     }
 
     public function getSupportedTypes(?string $format): array
     {
-        return ['*' => true];
+        return $this->getFormat() === $format ? [ConstraintViolationList::class => false] : [];
     }
 }

--- a/tests/HttpRepository/HttpRepositoryTest.php
+++ b/tests/HttpRepository/HttpRepositoryTest.php
@@ -2,8 +2,10 @@
 
 namespace Mtarld\ApiPlatformMsBundle\Tests\HttpRepository;
 
+use ApiPlatform\Metadata\Exception\ItemNotFoundException;
 use ApiPlatform\Validator\Exception\ValidationException;
 use Mtarld\ApiPlatformMsBundle\Exception\ResourceValidationException;
+use Mtarld\ApiPlatformMsBundle\Tests\Fixtures\App\src\Dto\ColorResourceDto;
 use Mtarld\ApiPlatformMsBundle\Tests\Fixtures\App\src\Dto\PuppyResourceDto;
 use Mtarld\ApiPlatformMsBundle\Tests\Fixtures\App\src\Entity\Puppy;
 use Mtarld\ApiPlatformMsBundle\Tests\Fixtures\App\src\HttpRepository\PuppyHttpRepository;
@@ -317,7 +319,10 @@ class HttpRepositoryTest extends KernelTestCase
         self::assertEquals(new PuppyResourceDto('/puppies/1', 'foo'), $createdPuppyDto);
     }
 
-    public function testCreateResourceWithViolations(): void
+    /**
+     * @dataProvider provideValidationFailureStatusCodes
+     */
+    public function testCreateResourceWithViolations(int $statusCode): void
     {
         $this->expectException(ResourceValidationException::class);
 
@@ -333,7 +338,7 @@ class HttpRepositoryTest extends KernelTestCase
                     'api_error_resource' => true,
                     'rfc_7807_compliant_errors' => true,
                 ]),
-                ['http_code' => 400]
+                ['http_code' => $statusCode]
             ),
         ]);
 
@@ -342,6 +347,36 @@ class HttpRepositoryTest extends KernelTestCase
         /** @var PuppyHttpRepository $httpRepository */
         $httpRepository = static::getContainer()->get(PuppyHttpRepository::class);
         $httpRepository->create(new PuppyResourceDto(null, 'foo'));
+    }
+
+    public static function provideValidationFailureStatusCodes(): iterable
+    {
+        yield 'bad request' => [400];
+        yield 'unprocessable entity' => [422];
+    }
+
+    public function testCreateResourceWithBadRequestWithoutViolations(): void
+    {
+        $this->expectException(ResourceValidationException::class);
+
+        /** @var SerializerInterface $serializer */
+        $serializer = static::getContainer()->get(SerializerInterface::class);
+        $violation = new ItemNotFoundException('Item not found for /api/colors/1');
+        $httpClient = new MockHttpClient([
+            new MockResponse(
+                $serializer->serialize($violation, 'jsonld', [
+                    'api_error_resource' => true,
+                    'rfc_7807_compliant_errors' => true,
+                ]),
+                ['http_code' => 400]
+            ),
+        ]);
+
+        static::getContainer()->set('test.http_client', $httpClient);
+
+        /** @var PuppyHttpRepository $httpRepository */
+        $httpRepository = static::getContainer()->get(PuppyHttpRepository::class);
+        $httpRepository->create(new PuppyResourceDto(null, 'foo', new ColorResourceDto('/colors/1', '#000000')));
     }
 
     public function testUpdateResource(): void


### PR DESCRIPTION
This PR makes `AbstractConstraintViolationListDenormalizer` fall through when the expected `violations` key is not present. 

Fixes #96.

This is maybe a suboptimal solution:

1. Normally denormalization would fall back to Symfony's AbstractObjectNormalizer, which would create a ConstraintViolationList with an empty list of violations. This leads to a [ResourceValidationException with an empty message](https://github.com/mtarld/api-platform-ms-bundle/blob/6f2a82aab38ab6a81b3da9dc20528d3c407d94b4/src/Exception/ResourceValidationException.php#L15), which is not that good for DX. It is maybe better to drop the 400 status code case, but I'm not sure if this would be BC (in case someone has mapped it that way)
2. Adding the 422 status code response might be considered a BC break as well. Previously client code would catch `Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface` and do the handling themselves. Now they must handle `Mtarld\ApiPlatformMsBundle\Exception\ResourceValidationException`.

